### PR TITLE
Refresh docs, add examples and add missing features

### DIFF
--- a/docs/api-libraries.md
+++ b/docs/api-libraries.md
@@ -35,13 +35,13 @@ For additional information and usage instructions, visit <https://github.com/dat
 
 To get the current released version from CRAN:
 
-```bash
+```r
 install.packages("data.world")
 ```
 
 To get the current development version from GitHub:
 
-```bash
+```r
 devtools::install_github("datadotworld/data.world-r", build_vignettes = TRUE)
 ```
 
@@ -58,13 +58,13 @@ For additional information and usage instructions, visit <https://github.com/dat
 The **OpenAPI Specification** (formerly Swagger Specification) is an API description format for REST APIs. An OpenAPI file allows you to describe your entire API, including:
 
 * Available endpoints (`/users`) and operations on each endpoint (`GET /users`, `POST /users`)
-* Operation parameters Input and output for each operation
+* Operation parameters (input and output) for each operation
 * Authentication methods
 * Contact information, license, terms of use and other information.
 
-API specifications can be written in YAML or JSON. The format is easy to learn and is both human-redable and machine-readable.
+API specifications can be written in YAML or JSON. The format is easy to learn and is both human-readable and machine-readable.
 
-data.world's public API especification is available at <https://api.data.world/v0/swagger.json>
+data.world's public API specification is available at <https://api.data.world/v0/swagger.json>
 
 The complete OpenAPI Specification can be found on GitHub:
 [OpenAPI 3.0 Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)

--- a/docs/api-libraries.md
+++ b/docs/api-libraries.md
@@ -7,59 +7,79 @@ ActionScript, Apex, Bash, C#, C++, Clojure, Dart, Elixir, Eiffel, Go, Groovy, Ha
 
 ## Installation
 
-You can install it using pip directly from PyPI:
+You can install it using pip directly from [PyPI](https://pypi.python.org/pypi/datadotworld):
 
-```sh
+```bash
 pip install datadotworld
 ```
 
 Optionally, you can install the library including pandas support:
 
-```sh
+```bash
 pip install datadotworld[pandas]
 ``` 
 
-If you use conda to manage your python distribution, you can install from the community-maintained [conda-forge](https://conda-forge.github.io/) channel:
+If you use conda to manage your python distribution, you can install from the community-maintained [conda-forge](https://anaconda.org/conda-forge/datadotworld-py) channel:
 
-```sh
+```bash
 conda install -c conda-forge datadotworld-py
 ```
 
 ## Usage
 
-For addition information and usage instructions, visit <https://github.com/datadotworld/data.world-py>
+For additional information and usage instructions, visit <https://github.com/datadotworld/data.world-py>
 
 # R
 
 To get the current released version from CRAN:
 
-```sh
+```bash
 install.packages("data.world")
 ```
 
 To get the current development version from GitHub:
 
-```sh
+```bash
 devtools::install_github("datadotworld/data.world-r", build_vignettes = TRUE)
 ```
 
 ## Usage
 
-For addition information and usage instructions, visit <https://github.com/datadotworld/data.world-r>
+For additional information and usage instructions, visit <https://github.com/datadotworld/data.world-r>
 
-# Swagger Codegen
+# Swagger
 
-## Prerequisites
+## What is Swagger?
+
+**Swagger** is a set of open-source tools built around the OpenAPI Specification that can help you design, build, document and consume REST APIs.
+
+The **OpenAPI Specification** (formerly Swagger Specification) is an API description format for REST APIs. An OpenAPI file allows you to describe your entire API, including:
+
+* Available endpoints (`/users`) and operations on each endpoint (`GET /users`, `POST /users`)
+* Operation parameters Input and output for each operation
+* Authentication methods
+* Contact information, license, terms of use and other information.
+
+API specifications can be written in YAML or JSON. The format is easy to learn and is both human-redable and machine-readable.
+
+data.world's public API especification is available at <https://api.data.world/v0/swagger.json>
+
+The complete OpenAPI Specification can be found on GitHub:
+[OpenAPI 3.0 Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)
+
+## Swagger Codegen
+
+### Prerequisites
 If you're looking for the latest stable version, you can grab it directly from Maven.org (Java 7 runtime at a minimum):
 
-```sh
+```bash
 wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O swagger-codegen-cli.jar
 
 java -jar swagger-codegen-cli.jar help
 ```
 
-On a mac, it's even easier with `brew`:
-```sh
+On a mac, it's even easier with `brew` (<https://brew.sh/>):
+```bash
 brew install swagger-codegen
 ```
 
@@ -69,10 +89,10 @@ To build from source, you need the following installed and available in your $PA
 
 * [Apache maven 3.3.3 or greater](http://maven.apache.org/)
 
-## Usage
+### Usage
 
 Here is an example usage (assuming tool was installed with Homebrew):
-```sh
+```bash
 swagger-codegen generate -i https://api.data.world/v0/swagger.json -l ruby -o /dw-api-ruby
 ```
 

--- a/docs/api-libraries.md
+++ b/docs/api-libraries.md
@@ -1,0 +1,79 @@
+data.world maintains implementations of API libraries in **Python** and **R**. 
+
+In addition, libraries can be automatically generated for many more languages using the Swagger Codegen tool, including: 
+ActionScript, Apex, Bash, C#, C++, Clojure, Dart, Elixir, Eiffel, Go, Groovy, Haskell, Java, Kotlin, Node.js, Objective-C, Perl, PHP, PowerShell, Ruby, Scala, Swift and Typescript.
+
+# Python
+
+## Installation
+
+You can install it using pip directly from PyPI:
+
+```sh
+pip install datadotworld
+```
+
+Optionally, you can install the library including pandas support:
+
+```sh
+pip install datadotworld[pandas]
+``` 
+
+If you use conda to manage your python distribution, you can install from the community-maintained [conda-forge](https://conda-forge.github.io/) channel:
+
+```sh
+conda install -c conda-forge datadotworld-py
+```
+
+## Usage
+
+For addition information and usage instructions, visit <https://github.com/datadotworld/data.world-py>
+
+# R
+
+To get the current released version from CRAN:
+
+```sh
+install.packages("data.world")
+```
+
+To get the current development version from GitHub:
+
+```sh
+devtools::install_github("datadotworld/data.world-r", build_vignettes = TRUE)
+```
+
+## Usage
+
+For addition information and usage instructions, visit <https://github.com/datadotworld/data.world-r>
+
+# Swagger Codegen
+
+## Prerequisites
+If you're looking for the latest stable version, you can grab it directly from Maven.org (Java 7 runtime at a minimum):
+
+```sh
+wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O swagger-codegen-cli.jar
+
+java -jar swagger-codegen-cli.jar help
+```
+
+On a mac, it's even easier with `brew`:
+```sh
+brew install swagger-codegen
+```
+
+To build from source, you need the following installed and available in your $PATH:
+
+* [Java 7 or 8](http://java.oracle.com)
+
+* [Apache maven 3.3.3 or greater](http://maven.apache.org/)
+
+## Usage
+
+Here is an example usage (assuming tool was installed with Homebrew):
+```sh
+swagger-codegen generate -i https://api.data.world/v0/swagger.json -l ruby -o /dw-api-ruby
+```
+
+For additional information, visit: <https://swagger.io/swagger-codegen/>

--- a/docs/api-libraries.md
+++ b/docs/api-libraries.md
@@ -3,6 +3,8 @@ data.world maintains implementations of API libraries in **Python** and **R**.
 In addition, libraries can be automatically generated for many more languages using the Swagger Codegen tool, including: 
 ActionScript, Apex, Bash, C#, C++, Clojure, Dart, Elixir, Eiffel, Go, Groovy, Haskell, Java, Kotlin, Node.js, Objective-C, Perl, PHP, PowerShell, Ruby, Scala, Swift and Typescript.
 
+**Java Users**: Check our data.world's [JDBC driver](https://github.com/datadotworld/dw-jdbc), available on [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cdw-jdbc).
+
 # Python
 
 ## Installation

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,47 +1,47 @@
 data.world supports the OAuth 2.0 protocol for authentication and authorization. If you are new to OAuth 2.0, the [OAuth Bible](http://oauthbible.com/) is a good place to start and learn some of the theory. Presently, data.world only supports the Authorization Code Grant flow (a.k.a. 3-legged OAuth).
 
-To request client keys email <help@data.world>  
+To request client keys email <help@data.world> including the name of your app, a URL for 75x75 logo for your app, the `redirect_uri` you intend to use. 
 
 # Auth Steps
 
 All applications follow a basic pattern when accessing a data.world API using OAuth 2.0.
 
-1. Application redirects User to https://data.world/oauth/authorize for Authorization, providing the following parameters:  
+1. Application redirects user to `https://data.world/oauth/authorize` for authorization, providing the following parameters:  
   `client_id`  
   `redirect_uri`  
   `response_type = "code"`  
   `state`
 
-**Example Authorization URL:**  
-```
-https://data.world/oauth/authorize?
-  client_id=3MVG9lKcPoNINVB&
-  redirect_uri=http://localhost/oauth/code_callback&
-  response_type=code
-```
+    **Example Authorization URL:**  
+    ```
+    https://data.world/oauth/authorize?
+      client_id=3MVG9lKcPoNINVB&
+      redirect_uri=http://localhost/oauth/code_callback&
+      response_type=code
+    ```
 
-2. User logs into data.world and grants Application access.  
+2. User logs into data.world and grants application access.  
 
-3. data.world redirects user back to the redirect_uri with:  
+3. data.world redirects user back to the `redirect_uri` with:  
   `code`  
   `state`
 
-4. Application takes the `code` and exchanges it for an Access Token:  
+4. Application takes the `code` and exchanges it for an access token:  
   `client_id`  
   `client_secret`  
   `code`  
   `redirect_uri` *Optional*  
   `grant_type = "authorization_code"`  
 
-**Example Token Request:**
-```
-POST
-https://data.world/oauth/authorize?
-  code=zac4ZV2XbleQ2e&
-  client_id=3MVG9lKcPoNINVB&
-  client_secret=3iQF9BsWEr6nCf&
-  grant_type=authorization_code
-```
+    **Example Token Request:**
+    ```
+    POST
+    https://data.world/oauth/access_token?
+      code=zac4ZV2XbleQ2e&
+      client_id=3MVG9lKcPoNINVB&
+      client_secret=3iQF9BsWEr6nCf&
+      grant_type=authorization_code
+    ```
 
 5. If `client_id` and `client_secret` are valid data.world will respond with:  
   `access_token`  
@@ -55,6 +55,13 @@ This flow requires that your application run on a web server, so that step #3 an
 
 **DO NOT** include your `client_secret` in source code that accessible to others or client-side apps as they can easily be reverse engineered. See the following section for additional instructions.
 
+# Reference implementation
+
+Check out our reference implementation on [GitHub](https://github.com/datadotworld/connector-oauth).   
+This example, written in Node.js can be deployed to your Heroku account as-is with click of a button. Super easy!  
+Look for the **Deploy to Heroku** button at the bottom of the README.md.
+
 ## Client-side apps
 
-Static sites and installed apps can safely integrate OAuth 2.0 if paired with a simple web app built and deployed exclusively to supports steps #3 and #4. That can be done with one-click and for free using GitHub+Heroku. Check out how, [here](https://github.com/datadotworld/connector-oauth).
+Static sites and installed apps can safely integrate OAuth 2.0 if paired with a simple web app built and deployed exclusively to supports steps #3 and #4.  
+That can be accomplished easily using the same reference implementation referenced above.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -222,7 +222,7 @@ All data.world API calls require an API token. After logging into data.world, fi
 
 Authentication must be provided in API requests via the `Authorization` header. For example, for a user whose API token is `my_api_token`, the request header should be `Authorization: Bearer my_api_token`.
 
-Those developing applications and integrations are encouraged to implement authentication directly within their apps via OAuth.
+Those developing applications and integrations are encouraged to implement authentication directly within their apps via #docTextSection:QRKZGmkzDw89ibrYm.
 
 ## Content type  
 By default, `application/json` is the content type used in request and response bodies. Exceptions are noted in respective endpoint documentation.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -155,9 +155,10 @@ Hunters Point Ave,7-7 Express
 
 Query results can be obtained in a variety of different formats, including:
 
-- `text/tsv`: Tab-separated values
+- `text/csv`: Comma-separated values
+- `text/tab-separated-values`: Tab-separated values
 - `application/json`: JSON array
-- `application/x-ndjson` and `application/json-l`: JSON lines
+- `application/x-ndjson` and `application/json-l`: [JSON lines](http://jsonlines.org/)
 
 When requesting a JSON format, you can obtain schema information alongside the data.
 To do that, add `includeTableSchema=true` in the query string. 
@@ -210,7 +211,7 @@ Notice that the first line is the [table schema](https://specs.frictionlessdata.
 ## Next steps
 
 1. Take some time to read the "Conventions" section below and to explore more endpoints and their documentation.
-2. Check out existing [integrations](https://data.world/integrations) and to see if an integration for your favorite tools already exist, and skip using this API altogether. *Pro tip:* come back often as we are constantly implementing new integrations.
+2. Check out existing [integrations](https://data.world/integrations) to see if an integration for your favorite tools already exists, and skip using this API altogether. *Pro tip:* come back often as we are constantly implementing new integrations.
 3. Learn how easily you can generate #docTextSection:8NpYGToZm2LsA9A9J for the language of your choice.
 4. Browse all endpoints and use the **Try it out** feature to interact with them in your browser.
 5. Let us know what cool things you create and make sure to reach out if you need support. We are at <help@data.world> and would love to hear from you!

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,6 @@
-data.world's mission is to build the most meaningful, collaborative, and abundant data resource in the world, so that people who work with data can solve problems faster. As part of that mission, we want to ensure that our users are able to easily access data and manage their data projects regardless of system or tool preference.
+data.world is designed for data and the people who work with data.  From professional projects to open data, data.world helps you host and share your data, collaborate with your team, and capture context and conclusions as you work.  
+
+Using this API users are able to easily access data and manage their data projects regardless of language or tool of preference. 
 
 # Quick Start
 
@@ -36,7 +38,7 @@ Now, let's see how files can be added to datasets.
 
 Files can be added to datasets via direct upload or by reference, using the URL of a file that is hosted publicly on the web.
 
-For example, we can get a complete list of NYC subway stations from data.cityofnewyork.us in CSV format at https://data.cityofnewyork.us/api/views/kk4q-3rt2/rows.csv?accessType=DOWNLOAD
+For example, we can get a complete list of NYC subway stations from data.cityofnewyork.us in CSV format at <https://data.cityofnewyork.us/api/views/kk4q-3rt2/rows.csv?accessType=DOWNLOAD>
 
 You can add that file to our `API Sandbox` dataset using the #endpoint:ujqwuHZYZP8yRKgcz endpoint with the following command:
 
@@ -75,7 +77,7 @@ As a result, the server response should look like this:
 
 Processing of uploaded files is asyncrhonous and finishes quickly. However, large files can take a few minutes to process. Once the dataset is in `LOADED` status, the data is ready to be consumed.
 
-Let's look at how you can check the status of a dataset
+Let's look at how you can check the status of a dataset.
 
 ## Retrieving dataset info
 
@@ -122,17 +124,17 @@ Note that `syncStatus` is `OK` and `status` is `LOADED`. That indicates that the
 
 ## Querying with SQL
 
-Now that the dataset is ready to be used, we can, for example, discover which NYC subway stations the `7 Express` train stops at using the `query.data.world` API. For example:
+Now that the dataset is ready to be used, we can, for example, discover which NYC subway stations the `7 Express` train stops at using the #endpoint:AYbqu2jrzNYYr9xsW endpoint. For example:
 
 ```bash
 curl --request POST \
-  --url "https://query.data.world/sql/${DW_USERNAME}/api-sandbox" \
+  --url "https://api.data.world/v0/sql/${DW_USERNAME}/api-sandbox" \
   --header "authorization: Bearer ${DW_API_TOKEN}" \
   --header "accept: text/csv" \
-  --data-urlencode 'query=SELECT NAME, LINE FROM `nyc-subways` WHERE LINE LIKE "%7 Express%"'
+  --data-urlencode 'query=SELECT name, line FROM nyc_subways WHERE line LIKE "%7 Express%"'
 ```
 
-As a result, the server response shouldlook like this:
+As a result, the server response should look like this:
 ```
 NAME,LINE
 Vernon Blvd - Jackson Ave,7-7 Express
@@ -149,12 +151,69 @@ Court Sq,7-7 Express
 Hunters Point Ave,7-7 Express
 ```
 
+### Additional query options
+
+Query results can be obtained in a variety of different formats, including:
+
+- `text/tsv`: Tab-separated values
+- `application/json`: JSON array
+- `application/x-ndjson` and `application/json-l`: JSON lines
+
+When requesting a JSON format, you can obtain schema information alongside the data.
+To do that, add `includeTableSchema=true` in the query string. 
+The schema information will be the first element or row in the response. 
+
+Here is what the previous request would look like if modified to produce JSON lines including schema information:
+```bash
+curl --request POST \
+  --url "https://api.data.world/v0/sql/${DW_USERNAME}/api-sandbox?includeTableSchema=true" \
+  --header "authorization: Bearer ${DW_API_TOKEN}" \
+  --header "accept: application/json-l" \
+  --data-urlencode 'query=SELECT name, line FROM nyc_subways WHERE line LIKE "%7 Express%"'
+```
+
+In this case, this is what the response will look like:
+```
+{"fields":[{"name":"name","type":"string","rdfType":"http://www.w3.org/2001/XMLSchema#string"},{"name":"line","type":"string","rdfType":"http://www.w3.org/2001/XMLSchema#string"}]}
+{"name":"Vernon Blvd - Jackson Ave","line":"7-7 Express"}
+{"name":"Queensboro Plz","line":"7-7 Express-N-W"}
+{"name":"Times Sq - 42nd St","line":"7-7 Express"}
+{"name":"Grand Central - 42nd St","line":"7-7 Express"}
+{"name":"Mets - Willets Point","line":"7-7 Express"}
+{"name":"Junction Blvd","line":"7-7 Express"}
+{"name":"Flushing - Main St","line":"7-7 Express"}
+{"name":"5th Ave - Bryant Pk","line":"7-7 Express"}
+{"name":"34th St - Hudson Yards","line":"7-7 Express"}
+{"name":"Woodside - 61st St","line":"7-7 Express"}
+{"name":"Court Sq","line":"7-7 Express"}
+{"name":"Hunters Point Ave","line":"7-7 Express"}
+```
+
+Notice that the first line is the [table schema](https://specs.frictionlessdata.io/table-schema/), as expected:
+```json
+{
+   "fields":[
+      {
+         "name":"name",
+         "type":"string",
+         "rdfType":"http://www.w3.org/2001/XMLSchema#string"
+      },
+      {
+         "name":"line",
+         "type":"string",
+         "rdfType":"http://www.w3.org/2001/XMLSchema#string"
+      }
+   ]
+}
+```
+
 ## Next steps
 
 1. Take some time to read the "Conventions" section below and to explore more endpoints and their documentation.
-2. Find if you can benefit from existing integrations and skip using this API altogether, by checking our gallery at https://data.world/integrations. Come back often as we are constantly implementing new integrations.
-3. Check-out additional documentation and tutorials at https://help.data.world too.
-4. Let us know what cool things you create and make sure to reach out if you need support. We are at help@data.world and would love to hear from you!
+2. Check out existing [integrations](https://data.world/integrations) and to see if an integration for your favorite tools already exist, and skip using this API altogether. *Pro tip:* come back often as we are constantly implementing new integrations.
+3. Learn how easily you can generate #docTextSection:8NpYGToZm2LsA9A9J for the language of your choice.
+4. Browse all endpoints and use the **Try it out** feature to interact with them in your browser.
+5. Let us know what cool things you create and make sure to reach out if you need support. We are at <help@data.world> and would love to hear from you!
 
 # Conventions
 
@@ -171,13 +230,6 @@ By default, `application/json` is the content type used in request and response 
 ## HTTPS only  
 Our APIs can only be accessed via HTTPS
 
-## APIs
-At the moment, there are two entry points for data.world APIs:
-
-* [api.data.world](./query.md)
-* [query.data.world](./datasets.md)
-
-These will soon be consolidated under `api.data.world`.
-
-## Feedback
-We will continue to introduce more endpoints and functionality as we can, but if there are areas that you'd like to see additional functionality, or if you've come across things not working as expected, please let us know by emailing [help@data.world](mailto:help@data.world).
+# Feedback
+This API will continue to evolve and we are working constantly to make it richer and better.
+If you've got your own ideas and would like to share with us, please email [help@data.world](mailto:help@data.world) or join us on [Slack](https://slack.data.world/).

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ permissions and limitations under the License.
 
     <groupId>world.data.api</groupId>
     <artifactId>dwapi-spec</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.8.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>dwapi-spec</name>

--- a/src/main/resources/world/data/api/swagger.json
+++ b/src/main/resources/world/data/api/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "0.7.0",
+    "version": "0.8.1",
     "title": "data.world API",
     "termsOfService": "https://data.world/terms",
     "contact": {
@@ -13,7 +13,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "description": "data.world's mission is to build the most meaningful, collaborative, and abundant data resource in the world, so that people who work with data can solve problems faster.\nIn the context of that mission, this API ensures that our users are able to easily access data and manage their data projects regardless of system or tool preference.",
+    "description": "data.world is designed for data and the people who work with data.  From professional projects to open data, data.world helps you host and share your data, collaborate with your team, and capture context and conclusions as you work.  \nUsing this API users are able to easily access data and manage their data projects regardless of language or tool of preference. \nCheck out our [documentation](https://dwapi.apidocs.io) for tips on how to get started, tutorials and to interact with the API right within your browser.",
     "x-stoplight": {
       "id": "data-world/specs/data-world"
     }
@@ -44,13 +44,17 @@
     "https"
   ],
   "paths": {
-    "/download/{owner}/{id}" : {
-      "get" : {
-        "tags" : [ "download" ],
-        "summary" : "Download dataset",
-        "description" : "This endpoint will return a .zip of all files within the dataset.\"",
-        "operationId" : "downloadDataset",
-        "produces" : [ "application/zip" ],
+    "/download/{owner}/{id}": {
+      "get": {
+        "tags": [
+          "download"
+        ],
+        "summary": "Download dataset",
+        "description": "This endpoint will return a .zip containing all files within the dataset as originally uploaded.  \nIf you are interested retrieving clean data extracted from those files by data.world, check out `GET:/sql` and `GET:/sparql`.",
+        "operationId": "downloadDataset",
+        "produces": [
+          "application/zip"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/owner"
@@ -100,17 +104,21 @@
             "description": "**INTERNAL SERVER ERROR**\nThe server encountered an unexpected condition that prevented it from fulfilling the request."
           }
         },
-        "security" : [ {
-          "token" : [ ]
-        } ]
+        "security": [
+          {
+            "token": []
+          }
+        ]
       }
     },
-    "/file_download/{owner}/{id}/{file}" : {
-      "get" : {
-        "tags" : [ "download" ],
-        "summary" : "Download file",
-        "description" : "This endpoint will return the file from the latest dataset version.",
-        "operationId" : "downloadFile",
+    "/file_download/{owner}/{id}/{file}": {
+      "get": {
+        "tags": [
+          "download"
+        ],
+        "summary": "Download file",
+        "description": "This endpoint will return a file within the dataset as originally uploaded.  \nIf you are interested retrieving clean data extracted from those files by data.world, check out `GET:/sql` and `GET:/sparql`.",
+        "operationId": "downloadFile",
         "parameters": [
           {
             "$ref": "#/parameters/owner"
@@ -163,19 +171,26 @@
             "description": "**INTERNAL SERVER ERROR**\nThe server encountered an unexpected condition that prevented it from fulfilling the request."
           }
         },
-        "security" : [ {
-          "token" : [ ]
-        } ]
+        "security": [
+          {
+            "token": []
+          }
+        ]
       }
     },
-    "/sparql/{owner}/{id}" : {
-      "get" : {
-        "tags" : [ "sparql" ],
-        "summary" : "SPARQL query (via GET)",
-        "description" : "This endpoint executes SPARQL queries against a dataset.\nNew to SPARQL? Check out data.world's [SPARQL tutorial](https://docs.data.world/tutorials/sparql/) .",
-        "operationId" : "sparqlGet",
+    "/sparql/{owner}/{id}": {
+      "get": {
+        "tags": [
+          "sparql"
+        ],
+        "summary": "SPARQL query (via GET)",
+        "description": "This endpoint executes SPARQL queries against a dataset or data project.  \n\nSPARQL results are available in a variety of formats. By default, `application/sparql-results+json` will be returned. Set the `Accept` header to one of the following values in accordance with your preference:\n\n* `text/csv`\n* `text/tab-separated-values`\n* `application/sparql-results+xml`\n* `application/sparql-results+json`\n\nNew to SPARQL? Check out data.world's [SPARQL tutorial](https://docs.data.world/tutorials/sparql/).",
+        "operationId": "sparqlGet",
         "produces": [
-          "text/csv", "application/sparql-results+xml", "application/sparql-results+json", "text/tab-separated-values"
+          "text/csv",
+          "application/sparql-results+xml",
+          "application/sparql-results+json",
+          "text/tab-separated-values"
         ],
         "parameters": [
           {
@@ -229,19 +244,28 @@
             "description": "**INTERNAL SERVER ERROR**\nThe server encountered an unexpected condition that prevented it from fulfilling the request."
           }
         },
-        "security" : [ {
-          "token" : [ ]
-        } ]
+        "security": [
+          {
+            "token": []
+          }
+        ]
       },
-      "post" : {
-        "tags" : [ "sparql" ],
-        "summary" : "SPARQL query",
-        "description" : "This endpoint executes SPARQL queries against a dataset.\nNew to SPARQL? Check out data.world's [SPARQL tutorial](https://docs.data.world/tutorials/sparql/) .",
-        "operationId" : "sparqlPost",
-        "produces": [
-          "text/csv", "application/sparql-results+xml", "application/sparql-results+json", "text/tab-separated-values"
+      "post": {
+        "tags": [
+          "sparql"
         ],
-        "consumes" : [ "application/x-www-form-urlencoded"],
+        "summary": "SPARQL query",
+        "description": "This endpoint executes SPARQL queries against a dataset or data project.  \n\nSPARQL results are available in a variety of formats. By default, `application/sparql-results+json` will be returned. Set the `Accept` header to one of the following values in accordance with your preference:\n\n* `text/csv`\n* `text/tab-separated-values`\n* `application/sparql-results+xml`\n* `application/sparql-results+json`\n\nNew to SPARQL? Check out data.world's [SPARQL tutorial](https://docs.data.world/tutorials/sparql/).",
+        "operationId": "sparqlPost",
+        "produces": [
+          "text/csv",
+          "application/sparql-results+xml",
+          "application/sparql-results+json",
+          "text/tab-separated-values"
+        ],
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/owner"
@@ -255,7 +279,10 @@
         ],
         "responses": {
           "200": {
-            "description": "__OK__\nThe request has succeeded."
+            "description": "__OK__\nThe request has succeeded.",
+            "examples": {
+              "application/x-www-form-urlencoded": "{}"
+            }
           },
           "400": {
             "schema": {
@@ -294,19 +321,25 @@
             "description": "**INTERNAL SERVER ERROR**\nThe server encountered an unexpected condition that prevented it from fulfilling the request."
           }
         },
-        "security" : [ {
-          "token" : [ ]
-        } ]
+        "security": [
+          {
+            "token": []
+          }
+        ]
       }
     },
-    "/sql/{owner}/{id}" : {
-      "get" : {
-        "tags" : [ "sql" ],
-        "summary" : "SQL query (via GET)",
-        "description" : "This endpoint executes SQL queries against a dataset.\nNew to SQL? Check out data.world's [SQL manual](https://docs.data.world/tutorials/dwsql/) .",
-        "operationId" : "sqlGet",
+    "/sql/{owner}/{id}": {
+      "get": {
+        "tags": [
+          "sql"
+        ],
+        "summary": "SQL query (via GET)",
+        "description": "This endpoint executes SQL queries against a dataset.\n\nSQL results are available in a variety of formats. By default, `application/json` will be returned. Set the `Accept` header to one of the following values in accordance with your preference:\n\n* `text/csv`\n* `application/json`\n* `application/json-l`\n* `application/x-ndjson`\n\nNew to SQL? Check out data.world's [SQL manual](https://docs.data.world/tutorials/dwsql/) .",
+        "operationId": "sqlGet",
         "produces": [
-          "text/csv" , "application/json-l", "application/x-ndjson"
+          "text/csv",
+          "application/json-l",
+          "application/x-ndjson"
         ],
         "parameters": [
           {
@@ -363,18 +396,26 @@
             "description": "**INTERNAL SERVER ERROR**\nThe server encountered an unexpected condition that prevented it from fulfilling the request."
           }
         },
-        "security" : [ {
-          "token" : [ ]
-        } ]
+        "security": [
+          {
+            "token": []
+          }
+        ]
       },
-      "post" : {
-        "tags" : [ "sql" ],
-        "summary" : "SQL query",
-        "description" : "This endpoint executes SQL queries against a dataset.\nNew to SQL? Check out data.world's [SQL manual](https://docs.data.world/tutorials/dwsql/) .",
-        "operationId" : "sqlPost",
-        "consumes" : [ "application/x-www-form-urlencoded" ],
+      "post": {
+        "tags": [
+          "sql"
+        ],
+        "summary": "SQL query",
+        "description": "This endpoint executes SQL queries against a dataset.\n\nSQL results are available in a variety of formats. By default, `application/json` will be returned. Set the `Accept` header to one of the following values in accordance with your preference:\n\n* `text/csv`\n* `application/json`\n* `application/json-l`\n* `application/x-ndjson`\n\nNew to SQL? Check out data.world's [SQL manual](https://docs.data.world/tutorials/dwsql/) .",
+        "operationId": "sqlPost",
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
         "produces": [
-          "text/csv" , "application/json-l", "application/x-ndjson"
+          "text/csv",
+          "application/json-l",
+          "application/x-ndjson"
         ],
         "parameters": [
           {
@@ -431,9 +472,11 @@
             "description": "**INTERNAL SERVER ERROR**\nThe server encountered an unexpected condition that prevented it from fulfilling the request."
           }
         },
-        "security" : [ {
-          "token" : [ ]
-        } ]
+        "security": [
+          {
+            "token": []
+          }
+        ]
       }
     },
     "/datasets/{owner}": {
@@ -616,7 +659,69 @@
               "$ref": "#/definitions/DatasetSummaryResponse"
             },
             "examples": {
-              "application/json": "{\r\n  \"owner\": \"sya\",\r\n  \"id\": \"trumpworld\",\r\n  \"title\": \"TrumpWorld\",\r\n  \"description\": \"TrumpWorld Data\",\r\n  \"summary\": \"From the Buzzfeed article [Help Us Map TrumpWorld](https://www.buzzfeed.com/johntemplon/help-us-map-trumpworld)\\n>No American president has taken office with a giant network of businesses, investments, and corporate connections like that amassed by Donald J. Trump. His family and advisers have touched a staggering number of ventures, from a hotel in Azerbaijan to a poker company in Las Vegas.\\n\\n\\nCheck out the data.world docs on how to Upload & sync files from [**Google Sheets**](https://docs.data.world/documentation/api/googleSync.html) and [**Github**](https://docs.data.world/documentation/api/githubSync.html)   \\n\\n\\nSource: [github.com/BuzzFeedNews](https://github.com/BuzzFeedNews/trumpworld/tree/master/data)   \\n\\n_If you have suggestions for expanding or improving the dataset, please email trump@buzzfeed.com. If you’d like to send your tip securely and anonymously, see these [instructions](https://tips.buzzfeed.com/)._\",\r\n  \"tags\": [\r\n    \"trump\",\r\n    \"trump world\",\r\n    \"president\",\r\n    \"connections\",\r\n    \"swamp\",\r\n    \"business network\"\r\n  ],\r\n  \"visibility\": \"OPEN\",\r\n  \"files\": [\r\n    {\r\n      \"name\": \"org-org-connections.csv\",\r\n      \"sizeInBytes\": 97658,\r\n      \"source\": {\r\n        \"id\": \"bfbac3bb-9cec-410a-9ac4-c904a56d65fe\",\r\n        \"url\": \"https://raw.githubusercontent.com/BuzzFeedNews/trumpworld/master/data/org-org-connections.csv\",\r\n        \"syncStatus\": \"OK\",\r\n        \"lastSyncStart\": \"2017-02-06T22:55:15.242Z\",\r\n        \"lastSyncSuccess\": \"2017-02-06T22:55:15.258Z\",\r\n        \"lastSyncFailure\": \"2017-02-01T23:47:47.667Z\"\r\n      },\r\n      \"created\": \"2017-02-01T23:45:12.379Z\",\r\n      \"updated\": \"2017-02-03T16:05:03.241Z\"\r\n    },\r\n    {\r\n      \"name\": \"person-org-connections.csv\",\r\n      \"sizeInBytes\": 231637,\r\n      \"source\": {\r\n        \"id\": \"91cf66e3-4bd7-422f-a8ec-7de1b68f8ee1\",\r\n        \"url\": \"https://raw.githubusercontent.com/BuzzFeedNews/trumpworld/master/data/person-org-connections.csv\",\r\n        \"syncStatus\": \"OK\",\r\n        \"lastSyncStart\": \"2017-02-06T22:55:15.242Z\",\r\n        \"lastSyncSuccess\": \"2017-02-06T22:55:15.310Z\"\r\n      },\r\n      \"created\": \"2017-02-01T23:51:02.777Z\",\r\n      \"updated\": \"2017-02-03T16:05:03.241Z\"\r\n    },\r\n    {\r\n      \"name\": \"person-person-connections.csv\",\r\n      \"sizeInBytes\": 32556,\r\n      \"source\": {\r\n        \"id\": \"b1e0659b-c282-408a-893a-14b5e5a1ae4c\",\r\n        \"url\": \"https://raw.githubusercontent.com/BuzzFeedNews/trumpworld/master/data/person-person-connections.csv\",\r\n        \"syncStatus\": \"OK\",\r\n        \"lastSyncStart\": \"2017-02-06T22:55:15.242Z\",\r\n        \"lastSyncSuccess\": \"2017-02-06T22:55:15.361Z\"\r\n      },\r\n      \"created\": \"2017-02-01T23:51:32.492Z\",\r\n      \"updated\": \"2017-02-03T16:05:03.241Z\"\r\n    }\r\n  ],\r\n  \"status\": \"LOADED\",\r\n  \"created\": \"2017-02-01T22:33:58.809Z\",\r\n  \"updated\": \"2017-02-06T22:55:19.128Z\"\r\n}"
+              "application/json": {
+                "owner": "sya",
+                "id": "trumpworld",
+                "title": "TrumpWorld",
+                "description": "TrumpWorld Data",
+                "summary": "From the Buzzfeed article [Help Us Map TrumpWorld](https://www.buzzfeed.com/johntemplon/help-us-map-trumpworld)\n>No American president has taken office with a giant network of businesses, investments, and corporate connections like that amassed by Donald J. Trump. His family and advisers have touched a staggering number of ventures, from a hotel in Azerbaijan to a poker company in Las Vegas.\n\n\nCheck out the data.world docs on how to Upload & sync files from [**Google Sheets**](https://docs.data.world/documentation/api/googleSync.html) and [**Github**](https://docs.data.world/documentation/api/githubSync.html)   \n\n\nSource: [github.com/BuzzFeedNews](https://github.com/BuzzFeedNews/trumpworld/tree/master/data)   \n\n_If you have suggestions for expanding or improving the dataset, please email trump@buzzfeed.com. If you’d like to send your tip securely and anonymously, see these [instructions](https://tips.buzzfeed.com/)._",
+                "tags": [
+                  "trump",
+                  "trump world",
+                  "president",
+                  "connections",
+                  "swamp",
+                  "business network"
+                ],
+                "visibility": "OPEN",
+                "files": [
+                  {
+                    "name": "org-org-connections.csv",
+                    "sizeInBytes": 97658,
+                    "source": {
+                      "id": "bfbac3bb-9cec-410a-9ac4-c904a56d65fe",
+                      "url": "https://raw.githubusercontent.com/BuzzFeedNews/trumpworld/master/data/org-org-connections.csv",
+                      "syncStatus": "OK",
+                      "lastSyncStart": "2017-02-06T22:55:15.242Z",
+                      "lastSyncSuccess": "2017-02-06T22:55:15.258Z",
+                      "lastSyncFailure": "2017-02-01T23:47:47.667Z"
+                    },
+                    "created": "2017-02-01T23:45:12.379Z",
+                    "updated": "2017-02-03T16:05:03.241Z"
+                  },
+                  {
+                    "name": "person-org-connections.csv",
+                    "sizeInBytes": 231637,
+                    "source": {
+                      "id": "91cf66e3-4bd7-422f-a8ec-7de1b68f8ee1",
+                      "url": "https://raw.githubusercontent.com/BuzzFeedNews/trumpworld/master/data/person-org-connections.csv",
+                      "syncStatus": "OK",
+                      "lastSyncStart": "2017-02-06T22:55:15.242Z",
+                      "lastSyncSuccess": "2017-02-06T22:55:15.310Z"
+                    },
+                    "created": "2017-02-01T23:51:02.777Z",
+                    "updated": "2017-02-03T16:05:03.241Z"
+                  },
+                  {
+                    "name": "person-person-connections.csv",
+                    "sizeInBytes": 32556,
+                    "source": {
+                      "id": "b1e0659b-c282-408a-893a-14b5e5a1ae4c",
+                      "url": "https://raw.githubusercontent.com/BuzzFeedNews/trumpworld/master/data/person-person-connections.csv",
+                      "syncStatus": "OK",
+                      "lastSyncStart": "2017-02-06T22:55:15.242Z",
+                      "lastSyncSuccess": "2017-02-06T22:55:15.361Z"
+                    },
+                    "created": "2017-02-01T23:51:32.492Z",
+                    "updated": "2017-02-03T16:05:03.241Z"
+                  }
+                ],
+                "status": "LOADED",
+                "created": "2017-02-01T22:33:58.809Z",
+                "updated": "2017-02-06T22:55:19.128Z",
+                "isProject": false,
+                "accessLevel": "READ"
+              }
             }
           },
           "400": {
@@ -745,7 +850,7 @@
         "consumes": [
           "application/json"
         ],
-        "description": "Create a dataset with a given id or completely rewrite the dataset, including any previously added files, if one already exists with the given id",
+        "description": "Create a dataset with a given id or completely rewrite the dataset, including any previously added files, if one already exists with the given id.",
         "summary": "Create / Replace a dataset"
       },
       "patch": {
@@ -828,7 +933,7 @@
             "token": []
           }
         ],
-        "description": "Update an existing dataset. Note that we only update the elements or files included in the request. All omitted elements or files will remain untouched.",
+        "description": "Update an existing dataset. Note that only elements or files included in the request will be updated. All omitted elements or files will remain untouched.",
         "consumes": [
           "application/json"
         ]
@@ -918,7 +1023,7 @@
             "token": []
           }
         ],
-        "description": "This method allows files published on the web to be added to a data.world dataset via their URL. The source URL will be stored so you can easily update your file anytime it changes via the *fetch latest* link on the [data.world](https://data.world/) dataset page or by triggering the GET:/sync endpoint."
+        "description": "This method allows files published on the web to be added to a data.world dataset via their URL. The source URL will be stored so you can easily update your file anytime it changes via the *fetch latest* link on the [data.world](https://data.world/) dataset page or by triggering the GET:/sync endpoint.  \nCheck-out or tutorials for tips on how to add Google Sheets, GitHub and S3 files via URL and how to use webhooks or scripts to keep them always in sync."
       },
       "delete": {
         "tags": [
@@ -1001,7 +1106,7 @@
             "token": []
           }
         ],
-        "description": "Delete one or more files from a dataset by their name, including files added via URL."
+        "description": "Delete one or more files from a dataset by their name, including files added via URL.   \n\n**Batching**  \nNote that the `name` parameter can be include multiple times in the query string, once for each file that is to be deleted together in a single request."
       }
     },
     "/datasets/{owner}/{id}/files/{name}": {
@@ -1156,7 +1261,7 @@
             "token": []
           }
         ],
-        "description": "Update all files within a dataset that have originally been added via URL (e.g. via /datasets endpoints or on data.world)."
+        "description": "Update all files within a dataset that have originally been added via URL (e.g. via /datasets endpoints or on data.world). \nCheck-out or tutorials for tips on how to add Google Sheets, GitHub and S3 files via URL and how to use webhooks or scripts to keep them always in sync."
       },
       "post": {
         "tags": [
@@ -1227,7 +1332,7 @@
             "token": []
           }
         ],
-        "description": "Update all files within a dataset that have originally been added via URL (e.g. via /datasets endpoints or on data.world)."
+        "description": "Update all files within a dataset that have originally been added via URL (e.g. via /datasets endpoints or on data.world).  \nCheck-out or tutorials for tips on how to add Google Sheets, GitHub and S3 files via URL and how to use webhooks or scripts to keep them always in sync."
       }
     },
     "/uploads/{owner}/{id}/files": {
@@ -1236,7 +1341,7 @@
           "uploads"
         ],
         "summary": "Upload files",
-        "description": "Upload multiple files at once to a dataset via multipart request.\nSwagger clients will limit this method of upload to one file at a time. Other HTTP clients capable of making multipart/form-data requests can be used to upload multiple files in a single request.",
+        "description": "Upload multiple files at once to a dataset via multipart request.\n\nThis endpoint expects requests of type `multipart/form-data` and you can include one or more parts named `file`, each containing a different file to be uploaded.\n\nFor example, assuming that, you want to upload two local files named `file1.csv` and `file2.csv` to a hypothetical dataset `https://data.world/awesome-user/awesome-dataset`, this is what the cURL command would look like.\n\n```bash\ncurl \\\n  -H \"Authorization: <YOUR_API_TOKEN>\" \\\n  -F \"file=@file1.csv\" \\\n  -F \"file=@file2.csv\" \\\n  https://api.data.world/v0/uploads/awesome-user/awesome-dataset/files\n```\n\nSwagger clients will limit this method of upload to one file at a time. Other HTTP clients capable of making multipart/form-data requests can be used to upload multiple files in a single request.",
         "operationId": "uploadFiles",
         "consumes": [
           "multipart/form-data"
@@ -1257,6 +1362,13 @@
             "description": "Multipart-encoded file contents",
             "required": true,
             "type": "file"
+          },
+          {
+            "in": "query",
+            "name": "expandArchives",
+            "type": "boolean",
+            "default": false,
+            "description": "Indicates whether compressed files should be expanded upon upload."
           }
         ],
         "responses": {
@@ -1325,7 +1437,7 @@
           "uploads"
         ],
         "summary": "Upload file",
-        "description": "This method of upload is not supported by Swagger clients. Other HTTP clients can be used to supply the contents of the file directly in the body of the request",
+        "description": "Upload one file at a time to a dataset.\n\nThis endpoint expects requests of type `application/octet-stream`.\n\nFor example, assuming that you want to upload a local file named `file1.csv` to a hypothetical dataset `https://data.world/awesome-user/awesome-dataset` and choose its name on data.world to be `better-name.csv`, this is what the cURL command would look like.\n\n```bash\ncurl \\\n  -H \"Authorization: <YOUR_API_TOKEN>\" \\\n  -X PUT -H \"Content-Type: application/octet-stream\" \\\n  --data-binary @file1.csv \\\n  https://api.data.world/v0/uploads/awesome-user/awesome-dataset/files/better-name.csv\n```\n\nThis method of upload is typically not supported by Swagger clients. Other HTTP clients can be used to supply the contents of the file directly in the body of the request.",
         "operationId": "uploadFile",
         "consumes": [
           "application/octet-stream",
@@ -1349,6 +1461,13 @@
             "type": "string",
             "maxItems": 128,
             "minItems": 1
+          },
+          {
+            "in": "query",
+            "name": "expandArchive",
+            "type": "boolean",
+            "default": false,
+            "description": "Indicates whether a compressed file should be expanded upon upload."
           }
         ],
         "responses": {
@@ -1680,7 +1799,8 @@
     "token": {
       "type": "apiKey",
       "name": "Authorization",
-      "in": "header"
+      "in": "header",
+      "description": "All data.world API calls require an API token. After logging into data.world, find your token by navigating to your profile settings, under the Advanced tab or go to [https://data.world/settings/advanced](*https://data.world/settings/advanced*)\n\nAuthentication must be provided in API requests via the `Authorization` header. For example, for a user whose API token is `my_api_token`, the request header should be `Authorization: Bearer my_api_token`."
     }
   },
   "definitions": {
@@ -1758,10 +1878,10 @@
       "type": "object",
       "title": "Dataset Update Request",
       "properties": {
-        "title" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 60,
+        "title": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 60,
           "description": "Dataset name."
         },
         "description": {
@@ -1824,10 +1944,10 @@
       "type": "object",
       "title": "Dataset Replace Request",
       "properties": {
-        "title" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 60,
+        "title": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 60,
           "description": "Dataset name."
         },
         "description": {
@@ -1979,9 +2099,9 @@
           "type": "string",
           "description": "Date and time when the dataset was last updated."
         },
-        "isProject" : {
+        "isProject": {
           "type": "boolean",
-          "description": "Flag indicating if the dataset is also a project."
+          "description": "Every data project on data.world comes with a default dataset linked to it. This flag indicates if the dataset is a project's default dataset. "
         },
         "accessLevel": {
           "type": "string",
@@ -1992,7 +2112,7 @@
             "WRITE",
             "ADMIN"
           ],
-          "description": "The level of access the authenticated user is allowed with respect to dataset: \n\n*`NONE` Not allowed anything. \n*`DISCOVER` Allowed to know the dataset exists.. \n* `READ` Allowed to view and download dataset files, in addition to what DISCOVER allows. \n* `WRITE` Allowed to update data and metadata, in addition to what READ allows. \n* `ADMIN` Allowed to delete and manage access, in addition to what WRITE allows."
+          "description": "The level of access the authenticated user is allowed with respect to dataset: \n\n* `NONE` Not allowed any access.  \n* `DISCOVER` Allowed to know that the dataset exists.  \n* `READ` Allowed to view and download data and metadata, in addition to what DISCOVER allows. \n* `WRITE` Allowed to update data and metadata, in addition to what READ allows. \n* `ADMIN` Allowed to delete dataset, in addition to what WRITE allows."
         }
       },
       "required": [
@@ -2370,24 +2490,24 @@
       "required": true,
       "type": "string"
     },
-    "formQuery" : {
+    "formQuery": {
       "name": "query",
       "in": "formData",
-      "required": false,
+      "required": true,
       "type": "string"
     },
-    "includeTableSchema" : {
+    "includeTableSchema": {
       "name": "includeTableSchema",
       "in": "query",
       "required": false,
       "type": "boolean",
-      "default" : false,
+      "default": false,
       "description": "Flags indicating to include table schema in the response."
     },
-    "query" : {
+    "query": {
       "name": "query",
       "in": "query",
-      "required": false,
+      "required": true,
       "type": "string"
     },
     "limit": {


### PR DESCRIPTION
- Improved markdown docs
- Improved Swagger docs with better examples for `/uploads`, `/sql` and `/sparql`
- Added `expandArchive` and `expandArchives` params in `/uploads` endpoints