### PR TITLE
Fix version number in swagger.json

### DIFF
--- a/src/main/resources/world/data/api/swagger.json
+++ b/src/main/resources/world/data/api/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "0.9.0",
+    "version": "0.11.1",
     "title": "data.world API",
     "termsOfService": "https://data.world/terms",
     "contact": {


### PR DESCRIPTION
For a few releases, we've updated pom.xml but didn't update swagger.json accordingly. Fixing the version drift.