### PR TITLE
Support for ftp and ftps sync sources

### DIFF
--- a/src/main/resources/world/data/api/swagger.json
+++ b/src/main/resources/world/data/api/swagger.json
@@ -3766,10 +3766,10 @@
       "properties": {
         "url": {
           "type": "string",
-          "description": "Source URL of file. Must be an http, https, or stream URL.",
+          "description": "Source URL of file. Must be an http, https, ftp, ftps or stream URL.",
           "minLength": 1,
           "maxLength": 4096,
-          "pattern": "^(https?|stream):.*",
+          "pattern": "^(https?|ftps?|stream):.*",
           "format": "uri"
         },
         "method": {
@@ -3818,10 +3818,10 @@
       "properties": {
         "url": {
           "type": "string",
-          "description": "Source URL of file. Must be an http, https.",
+          "description": "Source URL of file. Must be an http, https, ftp, or ftps URL.",
           "minLength": 1,
           "maxLength": 4096,
-          "pattern": "^https?:.*",
+          "pattern": "^(https?|ftps?):.*",
           "format": "uri"
         },
         "method": {


### PR DESCRIPTION
Supports optional username & password credentials.

Does not support Oauth or custom `Authorization` header.

`ftps` urls only support TLS protocol and [explicit mode](https://en.wikipedia.org/wiki/FTPS#Explicit).
