### PR TITLE
Make url and method optional in FileSource objects

### DIFF
--- a/src/main/resources/world/data/api/swagger.json
+++ b/src/main/resources/world/data/api/swagger.json
@@ -564,10 +564,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "url",
-        "method"
-      ],
       "title": "File Source Create Or Update Request",
       "type": "object"
     },
@@ -616,10 +612,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "url",
-        "method"
-      ],
       "title": "File Create Request",
       "type": "object"
     },
@@ -678,8 +670,6 @@
         }
       },
       "required": [
-        "url",
-        "method",
         "syncStatus"
       ],
       "title": "File Source Response",

--- a/src/main/resources/world/data/api/swagger.json
+++ b/src/main/resources/world/data/api/swagger.json
@@ -1751,7 +1751,7 @@
     },
     "termsOfService": "https://data.world/terms",
     "title": "data.world API",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "x-stoplight": {
       "id": "data-world/specs/data-world"
     }


### PR DESCRIPTION
This isn't strictly backward compatible.  But relaxing this constraint is unlikely to break existing clients.