### PR TITLE
Add properties endpoint and unhide the virtual table endpoint

### DIFF
--- a/src/main/resources/world/data/api/swagger.json
+++ b/src/main/resources/world/data/api/swagger.json
@@ -3141,7 +3141,6 @@
         "tableType": {
           "description": "Table type",
           "enum": [
-            "EXTRACT",
             "VIRTUAL"
           ],
           "type": "string"
@@ -5772,8 +5771,8 @@
         "tags": [
           "tables"
         ],
-        "summary": "Add live or extracted tables from a virtual connection",
-        "description": "Add tables from an established virtual connection. For increased security, endpoints that interact with external connection sources require an Enterprise Admin Token. This token can be found under [Advanced Settings](https://data.world/settings/advanced). To learn more about the virtual connections data.world supports, please visit our [help protal](https://help.data.world/hc/en-us/sections/360009504254-Create-and-manage-virtual-connections).",
+        "summary": "Add live tables from a virtual connection",
+        "description": "Add tables from an established virtual connection. For increased security, endpoints that interact with external connection sources require an Enterprise Admin Token. This token can be found under [Advanced Settings](https://data.world/settings/advanced). To learn more about the virtual connections data.world supports, please visit our [help portal](https://help.data.world/hc/en-us/sections/360009504254-Create-and-manage-virtual-connections).",
         "operationId": "createNewTables",
         "consumes": [
           "application/json"
@@ -5901,8 +5900,7 @@
               "user_api_enterprise_admin"
             ]
           }
-        ],
-        "x-private": true
+        ]
       }
     },
     "/datasets/{owner}/{id}/v/{versionId}": {

--- a/src/main/resources/world/data/api/swagger.json
+++ b/src/main/resources/world/data/api/swagger.json
@@ -3314,6 +3314,9 @@
         "updateMethod"
       ]
     },
+    "StreamsResource": {
+      "type": "object"
+    },
     "Subscription": {
       "type": "object",
       "properties": {
@@ -12334,7 +12337,9 @@
           {
             "in": "body",
             "name": "body",
-            "schema": {}
+            "schema": {
+              "$ref": "#/definitions/StreamsResource"
+            }
           }
         ],
         "produces": [

--- a/src/main/resources/world/data/api/swagger.json
+++ b/src/main/resources/world/data/api/swagger.json
@@ -6038,6 +6038,102 @@
         ]
       }
     },
+    "/properties/{owner}": {
+      "get": {
+        "tags": [
+          "metadata/properties"
+        ],
+        "summary": "Get supported metadata properties by owner",
+        "description": "Get supported metadata properties by owner.\n\nThis endpoint can be used to obtain a reference list of supported custom metadata properties for your organization's catalog. Custom properties for resources in your catalog require an ApiBinding to be configured for use in the public API. For more information about how to correctly configure ApiBindings, please reach out to your data.world support representative or message help@data.world.",
+        "operationId": "getPropertiesByOwner",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "owner",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "User or organization id that owns the catalog you would like to get properties for."
+          },
+          {
+            "name": "categorylabel",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Resource category filter. example: “Business Term” or \"Report\""
+          },
+          {
+            "name": "typelabel",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Custom resource type. filter example: “PowerBI Dashboard”"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved properties",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "categoryLabel": "Report",
+                  "label": "Experts",
+                  "multivalued": false
+                },
+                {
+                  "categoryLabel": "Report",
+                  "label": "Impact Potential",
+                  "multivalued": false
+                }
+              ]
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/ErrorMessage"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/ErrorMessage"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorMessage"
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "$ref": "#/definitions/ErrorMessage"
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "schema": {
+              "$ref": "#/definitions/ErrorMessage"
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth": []
+          }
+        ]
+      }
+    },
     "/datasets/{owner}/{id}/v/{versionId}/dois/{doi}": {
       "delete": {
         "description": "Delete a DOI ([Digital Object Identifier](https://www.doi.org/)) associated with a version of a dataset.",
@@ -14198,6 +14294,9 @@
     },
     {
       "name": "metadata/glossary"
+    },
+    {
+      "name": "metadata/properties"
     },
     {
       "name": "metadata/relationships"


### PR DESCRIPTION
Primary addition is the new properties discovery endpoint to retrieve a list of supported custom properties via the API. 

Smaller corrections include:
-updating the StreamsResource reference, which was incorrectly referenced previously and was causing issues with endpoint autogeneration tasks in the Python SDK.
-temporarily hides the extract option for virtual tables. This will be added back when fully supported
-unhides the virtual table endpoint