### PR TITLE
Update references to main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,8 @@ prism conduct --spec src/main/resources/world/data/api/swagger.json src/test/spe
 Make sure your fork is up-to-date and create a feature branch for your feature or bug fix.
 
 ```bash
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git checkout -b my-feature-branch
 ```
 

--- a/release.sh
+++ b/release.sh
@@ -11,4 +11,4 @@ PAYLOAD="{
         \"CIRCLE_JOB\": \"release_build\"
     }
 }"
-curl -v -X POST -H "Content-Type: application/json" -d "${PAYLOAD}" "https://circleci.com/api/v1.1/project/github/datadotworld/dwapi-spec/tree/master?circle-token=${CIRCLE_TOKEN}"
+curl -v -X POST -H "Content-Type: application/json" -d "${PAYLOAD}" "https://circleci.com/api/v1.1/project/github/datadotworld/dwapi-spec/tree/main?circle-token=${CIRCLE_TOKEN}"


### PR DESCRIPTION
Update build scripts and documentation to use the new `main` branch name